### PR TITLE
Updating npm references

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@ This plugin requires Grunt.
 If you haven't used [Grunt](http://gruntjs.com/) before, be sure to check out the [Getting Started](http://gruntjs.com/getting-started) guide, as it explains how to create a [Gruntfile](http://gruntjs.com/sample-gruntfile) as well as install and use Grunt plugins. Once you're familiar with that process, you may install this plugin with this command:
 
 ```shell
-npm install scram --save-dev
+npm install grunt-scram --save-dev
 ```
 
 Once the plugin has been installed, it may be enabled inside your Gruntfile with this line of JavaScript:
 
 ```js
-grunt.loadNpmTasks('scram');
+grunt.loadNpmTasks('grunt-scram');
 ```
 
 ## The "scram" task
@@ -62,9 +62,22 @@ grunt.initConfig({
   scram: {
     options: {},
     files: {
-      "./build/app.scram.js" : ["./app.js"],
-    },
-  },
+      "./build/app.scram.js" : ["./app.js"]
+    }
+  }
+})
+```
+or...
+```js
+grunt.initConfig({
+  scram: {
+    build   : {
+      expand : true,
+      src    : [ '*.js' ],
+      dest   : 'build/js/',
+      cwd    : 'build/js/'
+    }
+  }
 })
 ```
 


### PR DESCRIPTION
The npm package name was wrong for `npm install scram' (needed to be`npm install grunt-scram`). I also added an extra example per my own usage pattern.
